### PR TITLE
Parse and display electrum transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ https://github.com/espressif/arduino-esp32/blob/master/docs/arduino-ide/boards_m
 ## Libraries Used
 - <a href="https://github.com/micro-bitcoin/uBitcoin">uBitcoin</a> (Download library from github and "Add Zip Library" in Arduino Library Manager) 
 - <a href="https://github.com/m5stack/M5Stack">M5Stack</a> (Install from "Library Manager" in Arduino)
+- [lvgl](https://lvgl.io/) (Install from "Library Manager" in Arduino, search as "lvgl", appears in the list as "lv_arduino")
 ## Materials
 - M5Stack (grey one is better) 
 - SD card (not sure if size is an issue for larger SD, 16GB works fine) 

--- a/bowser/bowser.ino
+++ b/bowser/bowser.ino
@@ -204,8 +204,8 @@ void loop() {
   else if(menuitem == 2){
     sdchecker();
     if (sdcommand.substring(0, 4) == "SIGN"){
-        String psbttx = sdcommand.substring(5, sdcommand.length() + 1);
- 
+        String eltx = sdcommand.substring(5, sdcommand.length() + 1);
+  
         ElectrumTx tx;
         
         M5.Lcd.fillScreen(BLACK);
@@ -224,14 +224,22 @@ void loop() {
         M5.Lcd.fillScreen(BLACK);
         M5.Lcd.setCursor(0, 20);
         M5.Lcd.setTextSize(2);
-
-        int len_parsed = tx.parse(psbttx);
+  
+        int len_parsed = tx.parse(eltx);
         if(len_parsed == 0){
           M5.Lcd.println("Can't parse tx");
           return;
         }
-        M5.Lcd.println("Unsigned tx");
-        M5.Lcd.println(tx);
+        for(int i=0; i<tx.tx.outputsNumber; i++){
+          M5.Lcd.print(tx.tx.txOuts[i].address());
+          M5.Lcd.print("\n-> ");
+          // Serial can't print uint64_t, so convert to int
+          M5.Lcd.print(int(tx.tx.txOuts[i].amount));
+          M5.Lcd.println(" sat\n");
+        }
+        M5.Lcd.print("Fee: ");
+        M5.Lcd.print(int(tx.fee()));
+        M5.Lcd.println(" sat");
 
        M5.Lcd.setCursor(0, 220);
        M5.Lcd.println("A to sign, C to cancel");


### PR DESCRIPTION
This PR changes the way how transaction is displayed.
Now it displays addresses, amounts in satoshi and the fee.
![bowser](https://user-images.githubusercontent.com/1706012/84317848-c39f3f80-ab6d-11ea-951a-12cc41e4419f.jpg)

Also adds a missing library dependency in the readme - lvgl is used in `gameimg.c`.